### PR TITLE
[#12] listener를 통해 Activity의 View 접근

### DIFF
--- a/app/src/main/java/com/june0122/wakplus/data/api/TwitchService.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/api/TwitchService.kt
@@ -7,7 +7,10 @@ import retrofit2.http.Query
 
 interface TwitchService {
     @GET("videos")
-    suspend fun getChannelVideos(@Query("user_id") userId: String): TwitchVideos
+    suspend fun getChannelVideos(
+        @Query("user_id") userId: String,
+        @Query("first") maxResults: Int = 20,
+    ): TwitchVideos
 
     @GET("users")
     suspend fun getUserInfo(@Query("id") userId: String): TwitchUserInfoSet

--- a/app/src/main/java/com/june0122/wakplus/data/api/YoutubeService.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/api/YoutubeService.kt
@@ -19,7 +19,7 @@ interface YoutubeService {
         @Query("part") part: String = "snippet",
         @Query("channelId") channelId: String,
         @Query("order") order: String,
-        @Query("maxResults") maxResults: Int = 8,
+        @Query("maxResults") maxResults: Int = 10,
     ): YoutubeChannelVideos
 
     @GET("videos")

--- a/app/src/main/java/com/june0122/wakplus/data/repository/TwitchRepository.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/repository/TwitchRepository.kt
@@ -8,7 +8,7 @@ import com.june0122.wakplus.data.entity.TwitchVideoInfo
 interface TwitchRepository {
     suspend fun getTwitchUserInfo(userId: String): TwitchUserInfo
 
-    suspend fun getTwitchVideos(idSet: IdSet): List<Content>
+    suspend fun getTwitchVideos(idSet: IdSet, maxResults: Int): List<Content>
 
     suspend fun createTwitchAccessToken(): String
 

--- a/app/src/main/java/com/june0122/wakplus/data/repository/YoutubeRepository.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/repository/YoutubeRepository.kt
@@ -5,7 +5,7 @@ import com.june0122.wakplus.data.entity.IdSet
 import com.june0122.wakplus.data.entity.YoutubeVideoInfo
 
 interface YoutubeRepository {
-    suspend fun getYoutubeVideos(idSet: IdSet, profileUrl: String): List<Content>
+    suspend fun getYoutubeVideos(idSet: IdSet, profileUrl: String, maxResults: Int): List<Content>
 
     suspend fun getYoutubeVideosByPlaylist(idSet: IdSet, profileUrl: String): List<Content>
 

--- a/app/src/main/java/com/june0122/wakplus/data/repository/impl/TwitchRepositoryImpl.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/repository/impl/TwitchRepositoryImpl.kt
@@ -19,14 +19,14 @@ class TwitchRepositoryImpl @Inject constructor(
     override suspend fun getTwitchUserInfo(userId: String): TwitchUserInfo =
         twitchApi.getUserInfo(userId).data[0]
 
-    override suspend fun getTwitchVideos(idSet: IdSet): List<Content> {
+    override suspend fun getTwitchVideos(idSet: IdSet, maxResults: Int): List<Content> {
         val twitchVideos = try {
             Log.e("TEST", "NO EXCEPTION")
-            twitchApi.getChannelVideos(idSet.twitchId).data
+            twitchApi.getChannelVideos(idSet.twitchId, maxResults).data
         } catch (e: Exception) {
             Log.e("TEST", "EXCEPTION : ${e.printStackTrace()}")
             storeTwitchAccessToken()
-            twitchApi.getChannelVideos(idSet.twitchId).data
+            twitchApi.getChannelVideos(idSet.twitchId, maxResults).data
         }
 
         val twitchUserInfo = twitchApi.getUserInfo(idSet.twitchId).data[0]

--- a/app/src/main/java/com/june0122/wakplus/data/repository/impl/YoutubeRepositoryImpl.kt
+++ b/app/src/main/java/com/june0122/wakplus/data/repository/impl/YoutubeRepositoryImpl.kt
@@ -12,9 +12,17 @@ import javax.inject.Inject
 class YoutubeRepositoryImpl @Inject constructor(
     private val youtubeApi: YoutubeService,
 ) : YoutubeRepository {
-    override suspend fun getYoutubeVideos(idSet: IdSet, profileUrl: String): List<Content> {
+    override suspend fun getYoutubeVideos(
+        idSet: IdSet,
+        profileUrl: String,
+        maxResults: Int,
+    ): List<Content> {
         return youtubeApi.run {
-            getChannelVideos(channelId = idSet.youtubeId, order = ORDER_BY_DATE)
+            getChannelVideos(
+                channelId = idSet.youtubeId,
+                order = ORDER_BY_DATE,
+                maxResults = maxResults
+            )
                 .items
                 .map { video ->
                     getVideoInfo(id = video.id.videoId)

--- a/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
@@ -59,8 +59,10 @@ class HomeFragment : Fragment() {
 
         if (context is DataLoadListener) {
             dataLoadListener = context
-        } else {
-            throw RuntimeException("$context must implement DataLoadListener")
+        }
+
+        if (this::dataLoadListener.isInitialized.not()) {
+            throw RuntimeException("lateinit property $dataLoadListener has not been initialized")
         }
     }
 

--- a/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.june0122.wakplus.ui.home
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -16,11 +17,11 @@ import com.june0122.wakplus.databinding.FragmentHomeBinding
 import com.june0122.wakplus.ui.home.adapter.ContentListAdapter
 import com.june0122.wakplus.ui.home.adapter.SnsListAdapter
 import com.june0122.wakplus.ui.home.adapter.StreamerListAdapter
-import com.june0122.wakplus.ui.main.MainActivity
 import com.june0122.wakplus.utils.CenterSmoothScroller
 import com.june0122.wakplus.utils.EmptyDataObserver
 import com.june0122.wakplus.utils.decorations.SnsPlatformItemDecoration
 import com.june0122.wakplus.utils.decorations.StreamerItemDecoration
+import com.june0122.wakplus.utils.listeners.DataLoadListener
 import com.june0122.wakplus.utils.listeners.StreamerClickListener
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -30,6 +31,7 @@ class HomeFragment : Fragment() {
     private lateinit var streamerRecyclerView: RecyclerView
     private lateinit var snsRecyclerView: RecyclerView
     private lateinit var contentRecyclerView: RecyclerView
+    private lateinit var dataLoadListener: DataLoadListener
     private val homeViewModel: HomeViewModel by viewModels()
     private val horizontalLayoutManager =
         LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
@@ -50,6 +52,16 @@ class HomeFragment : Fragment() {
     )
     private val snsListAdapter: SnsListAdapter = SnsListAdapter { position ->
         homeViewModel.onSnsClick(position)
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+
+        if (context is DataLoadListener) {
+            dataLoadListener = context
+        } else {
+            throw RuntimeException("$context must implement DataLoadListener")
+        }
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -83,10 +95,7 @@ class HomeFragment : Fragment() {
         }
 
         homeViewModel.isLoading.observe(viewLifecycleOwner) { status ->
-            (requireActivity() as MainActivity).binding.progressLoading.visibility = when (status) {
-                true -> View.VISIBLE
-                false -> View.GONE
-            }
+            dataLoadListener.onStatusChanged(status)
         }
     }
 

--- a/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
@@ -18,6 +18,7 @@ import com.june0122.wakplus.ui.home.adapter.SnsListAdapter
 import com.june0122.wakplus.ui.home.adapter.StreamerListAdapter
 import com.june0122.wakplus.ui.main.MainActivity
 import com.june0122.wakplus.utils.CenterSmoothScroller
+import com.june0122.wakplus.utils.EmptyDataObserver
 import com.june0122.wakplus.utils.decorations.SnsPlatformItemDecoration
 import com.june0122.wakplus.utils.decorations.StreamerItemDecoration
 import com.june0122.wakplus.utils.listeners.StreamerClickListener
@@ -113,8 +114,11 @@ class HomeFragment : Fragment() {
         }
 
         contentRecyclerView = binding.rvContent.apply {
+            val emptyObserver = EmptyDataObserver(binding.rvContent, binding.tvEmptyView)
             this.layoutManager = LinearLayoutManager(context)
-            adapter = contentListAdapter
+            adapter = contentListAdapter.apply {
+                registerAdapterDataObserver(emptyObserver)
+            }
         }
     }
 

--- a/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/home/HomeFragment.kt
@@ -16,6 +16,7 @@ import com.june0122.wakplus.databinding.FragmentHomeBinding
 import com.june0122.wakplus.ui.home.adapter.ContentListAdapter
 import com.june0122.wakplus.ui.home.adapter.SnsListAdapter
 import com.june0122.wakplus.ui.home.adapter.StreamerListAdapter
+import com.june0122.wakplus.ui.main.MainActivity
 import com.june0122.wakplus.utils.CenterSmoothScroller
 import com.june0122.wakplus.utils.decorations.SnsPlatformItemDecoration
 import com.june0122.wakplus.utils.decorations.StreamerItemDecoration
@@ -78,6 +79,13 @@ class HomeFragment : Fragment() {
 
         homeViewModel.streamers.observe(viewLifecycleOwner) { streamers ->
             streamerListAdapter.submitList(streamers)
+        }
+
+        homeViewModel.isLoading.observe(viewLifecycleOwner) { status ->
+            (requireActivity() as MainActivity).binding.progressLoading.visibility = when (status) {
+                true -> View.VISIBLE
+                false -> View.GONE
+            }
         }
     }
 

--- a/app/src/main/java/com/june0122/wakplus/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/home/HomeViewModel.kt
@@ -53,6 +53,9 @@ class HomeViewModel @Inject constructor(
     private val _streamers = MutableLiveData<List<StreamerEntity>>()
     val streamers: LiveData<List<StreamerEntity>> = _streamers
 
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> = _isLoading
+
     init {
         contentRepository.run {
             flowAllStreamers()
@@ -192,14 +195,17 @@ class HomeViewModel @Inject constructor(
             postValue(mutableListOf())
             postValue(checkedContent.sortByRecentUploads())
         }
+        _isLoading.postValue(false)
     }
 
     private fun collectStreamerContents(idSet: IdSet) {
         contentsJob = viewModelScope.launch(Dispatchers.IO) {
+            _isLoading.postValue(true)
             try {
                 val contents = fetchSnsContents(idSet)
                 updateContentsList(contents)
             } catch (e: CancellationException) {
+                _isLoading.postValue(false)
                 Log.e("TEST", "${e.message}")
             } finally {
                 Log.d("TEST", "Close contentsJob resources in finally")
@@ -209,6 +215,7 @@ class HomeViewModel @Inject constructor(
 
     fun collectAllStreamersContents() {
         contentsJob = viewModelScope.launch(Dispatchers.IO) {
+            _isLoading.postValue(true)
             try {
                 val contents = mutableListOf<Content>()
                 contentRepository.flowAllStreamers()
@@ -219,6 +226,7 @@ class HomeViewModel @Inject constructor(
                         updateContentsList(contents)
                     }.collect()
             } catch (e: CancellationException) {
+                _isLoading.postValue(false)
                 Log.e("TEST", "${e.message}")
             } finally {
                 Log.d("TEST", "Close contentsJob resources in finally")

--- a/app/src/main/java/com/june0122/wakplus/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/main/MainActivity.kt
@@ -12,7 +12,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : AppCompatActivity() {
-    private lateinit var binding: ActivityMainBinding
+    lateinit var binding: ActivityMainBinding
     private lateinit var navController: NavController
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/june0122/wakplus/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/june0122/wakplus/ui/main/MainActivity.kt
@@ -1,6 +1,7 @@
 package com.june0122.wakplus.ui.main
 
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
 import androidx.navigation.NavController
@@ -8,12 +9,20 @@ import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupWithNavController
 import com.june0122.wakplus.R
 import com.june0122.wakplus.databinding.ActivityMainBinding
+import com.june0122.wakplus.utils.listeners.DataLoadListener
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class MainActivity : AppCompatActivity() {
-    lateinit var binding: ActivityMainBinding
+class MainActivity : AppCompatActivity(), DataLoadListener {
+    private lateinit var binding: ActivityMainBinding
     private lateinit var navController: NavController
+
+    override fun onStatusChanged(isLoading: Boolean) {
+        when (isLoading) {
+            true -> binding.progressLoading.visibility = View.VISIBLE
+            false -> binding.progressLoading.visibility = View.GONE
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/june0122/wakplus/utils/EmptyDataObserver.kt
+++ b/app/src/main/java/com/june0122/wakplus/utils/EmptyDataObserver.kt
@@ -36,8 +36,8 @@ class EmptyDataObserver(
     }
 
     override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-        checkItemEmpty()
         super.onItemRangeInserted(positionStart, itemCount)
+        checkItemEmpty()
     }
 
     override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {

--- a/app/src/main/java/com/june0122/wakplus/utils/EmptyDataObserver.kt
+++ b/app/src/main/java/com/june0122/wakplus/utils/EmptyDataObserver.kt
@@ -1,0 +1,52 @@
+package com.june0122.wakplus.utils
+
+import android.view.View
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class EmptyDataObserver(
+    private val recyclerView: RecyclerView,
+    private val textView: TextView
+) : RecyclerView.AdapterDataObserver() {
+
+    init {
+        checkItemEmpty()
+    }
+
+    private fun checkItemEmpty() {
+        val isEmpty = recyclerView.adapter?.itemCount == 0
+        // val isEmpty = recyclerView.isEmpty() // 아이템이 존재하는데도 true를 반환하는 케이스가 있음
+        textView.visibility = if (isEmpty) View.VISIBLE else View.GONE
+    }
+
+    // DiffUtil에서 동작하지 않음
+    override fun onChanged() {
+        super.onChanged()
+        checkItemEmpty()
+    }
+
+    override fun onItemRangeChanged(positionStart: Int, itemCount: Int) {
+        super.onItemRangeChanged(positionStart, itemCount)
+        checkItemEmpty()
+    }
+
+    override fun onItemRangeChanged(positionStart: Int, itemCount: Int, payload: Any?) {
+        super.onItemRangeChanged(positionStart, itemCount, payload)
+        checkItemEmpty()
+    }
+
+    override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+        checkItemEmpty()
+        super.onItemRangeInserted(positionStart, itemCount)
+    }
+
+    override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
+        super.onItemRangeMoved(fromPosition, toPosition, itemCount)
+        checkItemEmpty()
+    }
+
+    override fun onItemRangeRemoved(positionStart: Int, itemCount: Int) {
+        super.onItemRangeRemoved(positionStart, itemCount)
+        checkItemEmpty()
+    }
+}

--- a/app/src/main/java/com/june0122/wakplus/utils/listeners/DataLoadListener.kt
+++ b/app/src/main/java/com/june0122/wakplus/utils/listeners/DataLoadListener.kt
@@ -1,0 +1,5 @@
+package com.june0122.wakplus.utils.listeners
+
+fun interface DataLoadListener {
+    fun onStatusChanged(isLoading: Boolean)
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -34,7 +34,20 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/nav_host_fragment"
-            app:menu="@menu/bottom_nav_menu" />
+            app:menu="@menu/bottom_nav_menu">
+
+        </com.google.android.material.bottomnavigation.BottomNavigationView>
+
+        <include
+            android:id="@+id/progress_loading"
+            layout="@layout/item_loading_progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/nav_host_fragment"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -120,7 +120,22 @@
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent"
-                    tools:listitem="@layout/item_youtube_video" />
+                    tools:listitem="@layout/item_youtube_video">
+
+                </androidx.recyclerview.widget.RecyclerView>
+
+                <TextView
+                    android:id="@+id/tv_empty_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="64dp"
+                    android:text="데이터가 없습니다."
+                    android:visibility="gone"
+                    android:textColor="@color/Text"
+                    android:textSize="18sp"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.core.widget.NestedScrollView>
     </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/item_loading_progress.xml
+++ b/app/src/main/res/layout/item_loading_progress.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <ProgressBar
+        android:id="@+id/paging_progressbar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        android:background="@drawable/bg_rounded_corner"
+        android:indeterminate="true"
+        android:indeterminateTint="@color/Primary"
+        android:paddingLeft="8dp"
+        android:paddingTop="8dp"
+        android:paddingRight="8dp"
+        android:paddingBottom="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_loading_progress.xml
+++ b/app/src/main/res/layout/item_loading_progress.xml
@@ -5,7 +5,7 @@
     android:layout_height="wrap_content">
 
     <ProgressBar
-        android:id="@+id/paging_progressbar"
+        android:id="@+id/progress_loading"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"


### PR DESCRIPTION
`MainActivity`에 정의된 view인 loading progressbar에 접근하기 위해 두 가지 방법 시도
- [12-loading-listener](https://github.com/f-lab-edu/wak-plus/tree/feature/12-loading-listener) : **listener**를 통해 Activity의 View 접근
- [12-loading-viewmodel](https://github.com/f-lab-edu/wak-plus/tree/feature/12-loading-viewmodel) : **이벤트 전달용 ViewModel**을 통해 loading status를 공유하여 Activity에서 View 처리